### PR TITLE
WIP - Add compose file for bringing up gw/gm cluster which share HDFS

### DIFF
--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       image: quay.io/geodocker/accumulo-geowave:latest
       command: master --auto-init
       environment:
+        INSTANCE_NAME: geowave
         HADOOP_MASTER_ADDRESS: hdfs-name
         ZOOKEEPERS: zookeeper
         ACCUMULO_PASSWORD: GisPwd
@@ -41,6 +42,7 @@ services:
         image: quay.io/geodocker/accumulo-geowave:latest
         command: monitor
         environment:
+          INSTANCE_NAME: geowave
           HADOOP_MASTER_ADDRESS: hdfs-name
           ZOOKEEPERS: zookeeper
         ports:
@@ -52,6 +54,7 @@ services:
         image: quay.io/geodocker/accumulo-geowave:latest
         command: tserver
         environment:
+          INSTANCE_NAME: geowave
           HADOOP_MASTER_ADDRESS: hdfs-name
           ZOOKEEPERS: zookeeper
         depends_on:
@@ -61,28 +64,32 @@ services:
       image: quay.io/geodocker/accumulo-geomesa:latest
       command: master --auto-init
       environment:
+        INSTANCE_NAME: geomesa
         HADOOP_MASTER_ADDRESS: hdfs-name
         ZOOKEEPERS: zookeeper
         ACCUMULO_PASSWORD: GisPwd
       depends_on:
         - zookeeper
     geomesa-monitor:
-        image: quay.io/geodocker/accumulo-geomesa:latest
-        command: monitor
-        environment:
-          HADOOP_MASTER_ADDRESS: hdfs-name
-          ZOOKEEPERS: zookeeper
-        ports:
-          - 50096:50095
-        depends_on:
-          - zookeeper
-          - geomesa-master
+      image: quay.io/geodocker/accumulo-geomesa:latest
+      command: monitor
+      environment:
+        INSTANCE_NAME: geomesa
+        HADOOP_MASTER_ADDRESS: hdfs-name
+        ZOOKEEPERS: zookeeper
+      ports:
+        - 50096:50095
+      depends_on:
+        - zookeeper
+        - geomesa-master
     geomesa-tserver:
-        image: quay.io/geodocker/accumulo-geomesa:latest
-        command: tserver
-        environment:
-          HADOOP_MASTER_ADDRESS: hdfs-name
-          ZOOKEEPERS: zookeeper
-        depends_on:
-          - zookeeper
-          - geomesa-master
+      image: quay.io/geodocker/accumulo-geomesa:latest
+      command: tserver
+      environment:
+        INSTANCE_NAME: geomesa
+        HADOOP_MASTER_ADDRESS: hdfs-name
+        ZOOKEEPERS: zookeeper
+      depends_on:
+        - zookeeper
+        - geomesa-master
+

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -1,0 +1,88 @@
+version: '2'
+services:
+    geoserver:
+        image: quay.io/geodocker/geoserver:latest
+        ports:
+          - 9090:9090
+    hdfs-name:
+        image: quay.io/geodocker/hdfs:latest
+        command: name
+        environment:
+          HADOOP_MASTER_ADDRESS: hdfs-name
+        ports:
+          - 50070:50070
+        # volumes:
+        #   - '/data/gt/hdfs:/data/hdfs'
+    hdfs-data:
+        image: quay.io/geodocker/hdfs:latest
+        command: data
+        environment:
+          HADOOP_MASTER_ADDRESS: hdfs-name
+        depends_on:
+          - hdfs-name
+        # volumes:
+        #  - '/data/gt/hdfs:/data/hdfs'
+    zookeeper:
+        image: quay.io/geodocker/zookeeper:latest
+        ports:
+          - 2181:2181
+        #  volumes:
+        #   - '/data/gt/hdfs:/data/hdfs'
+    geowave-master:
+      image: quay.io/geodocker/accumulo-geowave:latest
+      command: master --auto-init
+      environment:
+        HADOOP_MASTER_ADDRESS: hdfs-name
+        ZOOKEEPERS: zookeeper
+        ACCUMULO_PASSWORD: GisPwd
+      depends_on:
+        - zookeeper
+    geowave-monitor:
+        image: quay.io/geodocker/accumulo-geowave:latest
+        command: monitor
+        environment:
+          HADOOP_MASTER_ADDRESS: hdfs-name
+          ZOOKEEPERS: zookeeper
+        ports:
+          - 50095:50095
+        depends_on:
+          - zookeeper
+          - geowave-master
+    geowave-tserver:
+        image: quay.io/geodocker/accumulo-geowave:latest
+        command: tserver
+        environment:
+          HADOOP_MASTER_ADDRESS: hdfs-name
+          ZOOKEEPERS: zookeeper
+        depends_on:
+          - zookeeper
+          - geowave-master
+    geomesa-master:
+      image: quay.io/geodocker/accumulo-geomesa:latest
+      command: master --auto-init
+      environment:
+        HADOOP_MASTER_ADDRESS: hdfs-name
+        ZOOKEEPERS: zookeeper
+        ACCUMULO_PASSWORD: GisPwd
+      depends_on:
+        - zookeeper
+    geomesa-monitor:
+        image: quay.io/geodocker/accumulo-geomesa:latest
+        command: monitor
+        environment:
+          HADOOP_MASTER_ADDRESS: hdfs-name
+          ZOOKEEPERS: zookeeper
+        ports:
+          - 50096:50095
+        depends_on:
+          - zookeeper
+          - geomesa-master
+    geomesa-tserver:
+        image: quay.io/geodocker/accumulo-geomesa:latest
+        command: tserver
+        environment:
+          HADOOP_MASTER_ADDRESS: hdfs-name
+          ZOOKEEPERS: zookeeper
+        depends_on:
+          - zookeeper
+          - geomesa-master


### PR DESCRIPTION
This PR adds a compose file which brings up (two separate) accumulo clusters. One for GeoMesa and the other for GeoWave. To conserve resources, we've opted for shared HDFS underneath while developing.

Note that accumulo monitoring is forwarded through port 50096 for the GeoMesa cluster.